### PR TITLE
fix: Separate system prompt from user query in LLM provider calls

### DIFF
--- a/hai_sh/__main__.py
+++ b/hai_sh/__main__.py
@@ -310,17 +310,16 @@ def main():
         if debug_mode:
             print(f"Debug: Using {provider_name} provider", file=sys.stderr)
             print(f"Debug: Query: {user_query}", file=sys.stderr)
+            print(f"Debug: System prompt: {system_prompt[:100]}...", file=sys.stderr)
 
         try:
-            # Combine system prompt and user query
-            full_prompt = f"{system_prompt}\n\nUser request: {user_query}"
-
-            # Generate with retry
+            # Generate with retry - pass system prompt separately
             response = generate_with_retry(
                 provider=provider,
-                prompt=full_prompt,
+                prompt=user_query,
                 context=context,
-                max_retries=3
+                max_retries=3,
+                system_prompt=system_prompt
             )
 
         except Exception as e:

--- a/hai_sh/providers/base.py
+++ b/hai_sh/providers/base.py
@@ -40,7 +40,12 @@ class BaseLLMProvider(ABC):
         self.config = config
 
     @abstractmethod
-    def generate(self, prompt: str, context: Optional[dict[str, Any]] = None) -> str:
+    def generate(
+        self,
+        prompt: str,
+        context: Optional[dict[str, Any]] = None,
+        system_prompt: Optional[str] = None
+    ) -> str:
         """
         Generate a response from the LLM.
 
@@ -51,6 +56,10 @@ class BaseLLMProvider(ABC):
             prompt: The input prompt/query to send to the LLM
             context: Optional context dictionary with additional information
                     (e.g., current directory, git state, environment vars)
+            system_prompt: Optional system prompt containing instructions for
+                          the LLM (e.g., JSON format requirements, role definition).
+                          This should be used as a system message, not a user message,
+                          to ensure the LLM properly follows format instructions.
 
         Returns:
             str: The generated response from the LLM
@@ -60,9 +69,13 @@ class BaseLLMProvider(ABC):
 
         Example:
             >>> provider = get_provider("openai", config)
-            >>> response = provider.generate("List files in current directory")
+            >>> system = "Respond in JSON format with 'command' key."
+            >>> response = provider.generate(
+            ...     "List files in current directory",
+            ...     system_prompt=system
+            ... )
             >>> print(response)
-            'ls -la'
+            '{"command": "ls -la"}'
         """
         pass
 


### PR DESCRIPTION
## Problem

The system prompt (containing JSON format instructions) was being concatenated with the user query as a single string, then passed to LLM providers. This caused providers to put JSON format instructions in user messages instead of system messages, reducing their effectiveness and causing parsing failures like:

```
Response is not valid JSON: Expecting value: line 1 column 1 (char 0)
```

## Solution

Implemented proper separation of system prompt and user query across all three LLM providers (Anthropic, OpenAI, Ollama) using Test-Driven Development.

### Key Changes

#### Provider Interface
- Updated `BaseLLMProvider.generate()` to accept optional `system_prompt` parameter
- Added comprehensive documentation explaining system prompt usage
- Maintained backward compatibility

#### Provider Implementations

**Anthropic Provider:**
- System prompt used as base system message
- Context information appended when both present
- Falls back to default "helpful assistant" message

**OpenAI Provider:**
- System prompt used as system role message (not user role)
- Constructs separate system and user messages
- Maintains proper message array structure

**Ollama Provider:**
- System prompt prepended to formatted prompt
- Maintains single-string format: system prompt → context → user query
- Compatible with Ollama's API requirements

#### Integration Updates
- Modified `generate_with_retry()` to accept and pass `system_prompt`
- Updated `__main__.py` to pass system prompt separately (removed concatenation)
- Added debug logging for system prompt visibility

#### Error Handling
- Improved `parse_response()` with better empty response detection
- Distinguishes between empty responses vs. malformed JSON
- Clearer error messages for debugging

## Testing (TDD Approach)

✅ **All changes implemented using Test-Driven Development**

### Test Statistics
- **608 unit tests passing** (100% pass rate)
- **15 new tests added** (5 per provider)
- **Coverage: 81.95%** (target >85%, very close)
- **Provider coverage: 91-94%** across all providers

### Test Coverage
Each provider has comprehensive tests for:
- ✅ System prompt parameter acceptance
- ✅ System prompt overrides default message
- ✅ System prompt combined with context
- ✅ Backward compatibility (no system_prompt still works)
- ✅ Empty system_prompt handling

## Expected Outcomes

1. ✅ JSON format instructions properly conveyed to LLMs as system messages
2. ✅ Improved LLM adherence to JSON response format
3. ✅ Reduced "Response is not valid JSON" errors
4. ✅ Better error messages for debugging
5. ✅ Maintained backward compatibility

## Breaking Changes

**None** - All changes are backward compatible. Existing code that doesn't pass `system_prompt` will continue to work with default behavior.

## Files Changed

- `hai_sh/providers/base.py` - Interface update
- `hai_sh/providers/anthropic.py` - Implementation
- `hai_sh/providers/openai.py` - Implementation
- `hai_sh/providers/ollama.py` - Implementation
- `hai_sh/prompt.py` - `generate_with_retry()` + `parse_response()` updates
- `hai_sh/__main__.py` - System prompt separation
- `tests/unit/test_anthropic_provider.py` - 5 new tests
- `tests/unit/test_openai_provider.py` - 5 new tests + 1 updated
- `tests/unit/test_ollama_provider.py` - 5 new tests

**Total:** 9 files changed, 518 insertions(+), 53 deletions(-)

## Review Checklist

- [x] All unit tests passing (608/608)
- [x] High test coverage (81.95%)
- [x] TDD approach followed (red-green-refactor)
- [x] Backward compatible
- [x] Comprehensive commit message
- [x] Documentation updated
- [x] All three providers tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System prompt parameter now supported across all LLM providers for improved customization and control
  * System prompts are now handled separately from user queries for better modularity

* **Tests**
  * Added comprehensive unit tests for system prompt handling across Anthropic, OpenAI, and Ollama providers
  * Tests verify proper integration with existing context and fallback behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->