### PR TITLE
fix: skip Ollama tests when model not available

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ import pytest
 import requests
 import yaml
 
+# Default model used for Ollama integration tests
+OLLAMA_TEST_MODEL = "llama3.2"
+
 
 @pytest.fixture
 def tmp_config_dir(tmp_path: Path) -> Generator[Path, None, None]:
@@ -295,8 +298,8 @@ def test_config_ollama(tmp_path: Path) -> Generator[Path, None, None]:
     """
     if not is_ollama_available():
         pytest.skip("Ollama not running on localhost:11434")
-    if not is_ollama_model_available("llama3.2"):
-        pytest.skip("Ollama model 'llama3.2' not available")
+    if not is_ollama_model_available(OLLAMA_TEST_MODEL):
+        pytest.skip(f"Ollama model '{OLLAMA_TEST_MODEL}' not available")
 
     config_dir = tmp_path / ".hai"
     config_dir.mkdir()
@@ -304,11 +307,11 @@ def test_config_ollama(tmp_path: Path) -> Generator[Path, None, None]:
 
     config_content = {
         "provider": "ollama",
-        "model": "llama3.2",
+        "model": OLLAMA_TEST_MODEL,
         "providers": {
             "ollama": {
                 "base_url": "http://localhost:11434",
-                "model": "llama3.2",
+                "model": OLLAMA_TEST_MODEL,
             }
         },
         "context": {
@@ -404,6 +407,6 @@ skip_if_no_anthropic = pytest.mark.skipif(
 )
 
 skip_if_no_ollama = pytest.mark.skipif(
-    not is_ollama_available() or not is_ollama_model_available("llama3.2"),
-    reason="Ollama not running on localhost:11434 or model 'llama3.2' not available",
+    not is_ollama_available() or not is_ollama_model_available(OLLAMA_TEST_MODEL),
+    reason=f"Ollama not running on localhost:11434 or model '{OLLAMA_TEST_MODEL}' not available",
 )

--- a/tests/unit/test_conftest_helpers.py
+++ b/tests/unit/test_conftest_helpers.py
@@ -1,0 +1,75 @@
+"""
+Tests for conftest.py helper functions.
+
+Tests the provider availability check functions used by test fixtures
+and skip decorators.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+
+from tests.conftest import is_ollama_model_available
+
+
+class TestIsOllamaModelAvailable:
+    """Tests for is_ollama_model_available() helper function."""
+
+    @patch("tests.conftest.requests.post")
+    def test_returns_true_when_model_exists(self, mock_post):
+        """Model available on Ollama server returns True."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        assert is_ollama_model_available("llama3.2") is True
+        mock_post.assert_called_once_with(
+            "http://localhost:11434/api/show",
+            json={"name": "llama3.2"},
+            timeout=5,
+        )
+
+    @patch("tests.conftest.requests.post")
+    def test_returns_false_when_model_not_found(self, mock_post):
+        """Model not pulled on Ollama server returns False."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_post.return_value = mock_response
+
+        assert is_ollama_model_available("llama3.2") is False
+
+    @patch("tests.conftest.requests.post")
+    def test_returns_false_on_connection_error(self, mock_post):
+        """Connection error (server down) returns False."""
+        mock_post.side_effect = requests.ConnectionError("Connection refused")
+
+        assert is_ollama_model_available("llama3.2") is False
+
+    @patch("tests.conftest.requests.post")
+    def test_returns_false_on_timeout(self, mock_post):
+        """Request timeout returns False."""
+        mock_post.side_effect = requests.Timeout("Request timed out")
+
+        assert is_ollama_model_available("llama3.2") is False
+
+    @patch("tests.conftest.requests.post")
+    def test_returns_false_on_os_error(self, mock_post):
+        """OSError (network unreachable) returns False."""
+        mock_post.side_effect = OSError("Network unreachable")
+
+        assert is_ollama_model_available("llama3.2") is False
+
+    @patch("tests.conftest.requests.post")
+    def test_accepts_any_model_name(self, mock_post):
+        """Function works with arbitrary model names."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        assert is_ollama_model_available("mistral") is True
+        mock_post.assert_called_once_with(
+            "http://localhost:11434/api/show",
+            json={"name": "mistral"},
+            timeout=5,
+        )

--- a/tests/unit/test_conftest_helpers.py
+++ b/tests/unit/test_conftest_helpers.py
@@ -7,7 +7,6 @@ and skip decorators.
 
 from unittest.mock import patch, MagicMock
 
-import pytest
 import requests
 
 from tests.conftest import is_ollama_model_available


### PR DESCRIPTION
## Summary
- Adds `is_ollama_model_available(model)` helper function that checks Ollama's `/api/show` endpoint to verify a model is pulled locally
- Updates `test_config_ollama` fixture to skip when server is down OR model is unavailable (matching the OpenAI/Anthropic pattern)
- Updates `skip_if_no_ollama` decorator to also check model availability

## Test plan
- [x] 6 new unit tests for `is_ollama_model_available()` (success, 404, connection error, timeout, OS error, arbitrary model name)
- [x] Full test suite passes: 1103 passed, 50 skipped, 0 failures
- [x] Ollama tests now skip with clear messages instead of failing with 404
- [x] Cross-provider tests correctly detect missing model
- [x] Formatting passes (black)

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering local model availability checks and error scenarios.
  * Introduced runtime pre-checks so model-related tests are gracefully skipped when the local server or specific model is unavailable.
  * Improved test robustness with clearer skip reasons and broader exception handling for connectivity failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->