### PR TITLE
feat: configurable Ollama test model via env var

### DIFF
--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -149,7 +149,19 @@ pytest tests/integration/test_integration_ollama.py::TestOllamaBasicGeneration::
 ```
 
 **Default Model Tested:**
-- `llama3.2` (8B parameters)
+- `llama3.2` (overridable via `HAI_TEST_OLLAMA_MODEL` env var)
+
+#### Using a Custom Ollama Model
+
+If you have a different model installed, set `HAI_TEST_OLLAMA_MODEL`:
+
+```bash
+# Run Ollama tests with a custom model
+HAI_TEST_OLLAMA_MODEL=mistral pytest -m "integration and ollama"
+
+# Make sure the model is pulled first
+ollama pull mistral
+```
 
 ### Testing All Providers
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -156,11 +156,11 @@ pytest tests/integration/test_integration_ollama.py::TestOllamaBasicGeneration::
 If you have a different model installed, set `HAI_TEST_OLLAMA_MODEL`:
 
 ```bash
-# Run Ollama tests with a custom model
-HAI_TEST_OLLAMA_MODEL=mistral pytest -m "integration and ollama"
-
-# Make sure the model is pulled first
+# First, make sure the model is pulled
 ollama pull mistral
+
+# Run Ollama tests with the custom model
+HAI_TEST_OLLAMA_MODEL=mistral pytest -m "integration and ollama"
 ```
 
 ### Testing All Providers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,9 @@ import pytest
 import requests
 import yaml
 
-# Default model used for Ollama integration tests
-OLLAMA_TEST_MODEL = "llama3.2"
+# Default model used for Ollama integration tests.
+# Override via HAI_TEST_OLLAMA_MODEL env var (e.g., HAI_TEST_OLLAMA_MODEL=mistral pytest -m ollama)
+OLLAMA_TEST_MODEL = os.environ.get("HAI_TEST_OLLAMA_MODEL", "llama3.2")
 
 
 @pytest.fixture

--- a/tests/integration/test_question_mode_real.py
+++ b/tests/integration/test_question_mode_real.py
@@ -167,10 +167,10 @@ def test_command_mode_still_works(ollama_config_file):
 def test_question_mode_vs_command_mode_detection(ollama_config_file):
     """Test that the system correctly distinguishes questions from commands."""
     # Question query
-    q_stdout, q_stderr, q_exit = run_hai("What is the purpose of chmod?", ollama_config_file)
+    q_stdout, _q_stderr, _q_exit = run_hai("What is the purpose of chmod?", ollama_config_file)
 
     # Command query
-    c_stdout, c_stderr, c_exit = run_hai("list files in current directory", ollama_config_file)
+    c_stdout, _c_stderr, _c_exit = run_hai("list files in current directory", ollama_config_file)
 
     # Question mode: no execution prompt
     assert "Execute this command?" not in q_stdout

--- a/tests/integration/test_question_mode_real.py
+++ b/tests/integration/test_question_mode_real.py
@@ -9,7 +9,7 @@ import subprocess
 import pytest
 import requests
 
-from tests.conftest import skip_if_no_ollama
+from tests.conftest import OLLAMA_TEST_MODEL, skip_if_no_ollama
 
 
 # Skip all tests in this module if Ollama is not available
@@ -27,27 +27,19 @@ def ollama_config_file(tmp_path):
     import yaml
 
     config = {
-        'provider': 'ollama',
-        'model': 'qwen3:8b',
-        'providers': {
-            'ollama': {
-                'base_url': 'http://localhost:11434',
-                'model': 'qwen3:8b'
-            }
+        "provider": "ollama",
+        "model": OLLAMA_TEST_MODEL,
+        "providers": {"ollama": {"base_url": "http://localhost:11434", "model": OLLAMA_TEST_MODEL}},
+        "context": {
+            "include_history": False,
+            "include_git_state": False,
+            "include_env_vars": False,
         },
-        'context': {
-            'include_history': False,
-            'include_git_state': False,
-            'include_env_vars': False
-        },
-        'output': {
-            'show_conversation': True,
-            'use_colors': False
-        }
+        "output": {"show_conversation": True, "use_colors": False},
     }
 
     config_file = tmp_path / "config.yaml"
-    with open(config_file, 'w') as f:
+    with open(config_file, "w") as f:
         yaml.dump(config, f)
 
     return config_file
@@ -65,20 +57,17 @@ def run_hai(query: str, config_file: str) -> tuple[str, str, int]:
         tuple: (stdout, stderr, exit_code)
     """
     result = subprocess.run(
-        ['python', '-m', 'hai_sh', '--config', str(config_file), query],
+        ["python", "-m", "hai_sh", "--config", str(config_file), query],
         capture_output=True,
         text=True,
-        timeout=60
+        timeout=60,
     )
     return result.stdout, result.stderr, result.returncode
 
 
 def test_question_mode_ls_flags(ollama_config_file):
     """Test question mode with a simple question about ls flags."""
-    stdout, stderr, exit_code = run_hai(
-        "What does the -la flag do in ls?",
-        ollama_config_file
-    )
+    stdout, stderr, exit_code = run_hai("What does the -la flag do in ls?", ollama_config_file)
 
     assert exit_code == 0, f"Command failed with stderr: {stderr}"
     assert stdout, "No output received"
@@ -98,8 +87,7 @@ def test_question_mode_ls_flags(ollama_config_file):
 def test_question_mode_difference_between_commands(ollama_config_file):
     """Test asking about the difference between two commands."""
     stdout, stderr, exit_code = run_hai(
-        "What's the difference between grep and awk?",
-        ollama_config_file
+        "What's the difference between grep and awk?", ollama_config_file
     )
 
     assert exit_code == 0, f"Command failed with stderr: {stderr}"
@@ -118,10 +106,7 @@ def test_question_mode_difference_between_commands(ollama_config_file):
 
 def test_question_mode_explain_concept(ollama_config_file):
     """Test asking for an explanation of a concept."""
-    stdout, stderr, exit_code = run_hai(
-        "How does pipe | work in bash?",
-        ollama_config_file
-    )
+    stdout, stderr, exit_code = run_hai("How does pipe | work in bash?", ollama_config_file)
 
     assert exit_code == 0, f"Command failed with stderr: {stderr}"
     assert stdout, "No output received"
@@ -138,10 +123,7 @@ def test_question_mode_explain_concept(ollama_config_file):
 
 def test_question_mode_when_to_use(ollama_config_file):
     """Test asking when to use a particular tool."""
-    stdout, stderr, exit_code = run_hai(
-        "When should I use sudo?",
-        ollama_config_file
-    )
+    stdout, stderr, exit_code = run_hai("When should I use sudo?", ollama_config_file)
 
     assert exit_code == 0, f"Command failed with stderr: {stderr}"
     assert stdout, "No output received"
@@ -158,10 +140,7 @@ def test_question_mode_when_to_use(ollama_config_file):
 
 def test_command_mode_still_works(ollama_config_file):
     """Verify command mode still works (regression test)."""
-    stdout, stderr, exit_code = run_hai(
-        "show me the current directory",
-        ollama_config_file
-    )
+    stdout, stderr, exit_code = run_hai("show me the current directory", ollama_config_file)
 
     # Note: Since this requires user confirmation, we expect it to fail
     # or produce output with the command and confirmation prompt
@@ -188,16 +167,10 @@ def test_command_mode_still_works(ollama_config_file):
 def test_question_mode_vs_command_mode_detection(ollama_config_file):
     """Test that the system correctly distinguishes questions from commands."""
     # Question query
-    q_stdout, q_stderr, q_exit = run_hai(
-        "What is the purpose of chmod?",
-        ollama_config_file
-    )
+    q_stdout, q_stderr, q_exit = run_hai("What is the purpose of chmod?", ollama_config_file)
 
     # Command query
-    c_stdout, c_stderr, c_exit = run_hai(
-        "list files in current directory",
-        ollama_config_file
-    )
+    c_stdout, c_stderr, c_exit = run_hai("list files in current directory", ollama_config_file)
 
     # Question mode: no execution prompt
     assert "Execute this command?" not in q_stdout

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,8 @@ Test utilities and helper functions for hai-sh tests.
 from pathlib import Path
 from typing import Any
 
+from tests.conftest import OLLAMA_TEST_MODEL
+
 
 def create_sample_config(config_dir: Path, provider: str = "ollama") -> Path:
     """
@@ -21,7 +23,7 @@ def create_sample_config(config_dir: Path, provider: str = "ollama") -> Path:
 
     config_data = {
         "provider": provider,
-        "model": "llama3.2" if provider == "ollama" else "gpt-4o-mini",
+        "model": OLLAMA_TEST_MODEL if provider == "ollama" else "gpt-4o-mini",
         "providers": {
             "openai": {
                 "api_key": "sk-test-key",
@@ -29,7 +31,7 @@ def create_sample_config(config_dir: Path, provider: str = "ollama") -> Path:
             },
             "ollama": {
                 "base_url": "http://localhost:11434",
-                "model": "llama3.2",
+                "model": OLLAMA_TEST_MODEL,
             },
         },
         "context": {


### PR DESCRIPTION
## Summary
- Adds `HAI_TEST_OLLAMA_MODEL` environment variable to override the default Ollama model (`llama3.2`) used in tests
- Centralizes the constant in `tests/conftest.py` and imports it in `tests/utils.py` and `tests/integration/test_question_mode_real.py`
- Documents the env var in `tests/TESTING.md`

## Breaking change
`tests/integration/test_question_mode_real.py` previously hardcoded `qwen3:8b`. It now uses the shared `OLLAMA_TEST_MODEL` constant which defaults to `llama3.2`. To restore the old behavior: `HAI_TEST_OLLAMA_MODEL=qwen3:8b pytest`.

## Test plan
- [x] All 1082 unit tests passing (3 new env var tests added)
- [x] Verified env var override works (`HAI_TEST_OLLAMA_MODEL=custom-model` is picked up)
- [x] Verified default fallback (`llama3.2`) when env var is unset
- [x] Black formatting clean
- [x] No circular import issues (conftest doesn't import from utils)

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Made the default Ollama model for testing configurable via the HAI_TEST_OLLAMA_MODEL environment variable (defaults to llama3.2).
  * Added unit tests validating default, env-var, and empty-string behaviors.
  * Updated integration tests to use the configurable model value.

* **Documentation**
  * Updated testing docs with steps to pull a custom Ollama model and run tests using HAI_TEST_OLLAMA_MODEL (example commands included).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->