### PR TITLE
fix: remove deprecated top-level model from test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,7 +203,6 @@ def test_config_openai(tmp_path: Path) -> Generator[Path, None, None]:
 
     config_content = {
         "provider": "openai",
-        "model": "gpt-4o-mini",
         "providers": {
             "openai": {
                 "api_key": api_key,
@@ -255,7 +254,6 @@ def test_config_anthropic(tmp_path: Path) -> Generator[Path, None, None]:
 
     config_content = {
         "provider": "anthropic",
-        "model": "claude-sonnet-4-5",
         "providers": {
             "anthropic": {
                 "api_key": api_key,
@@ -308,7 +306,6 @@ def test_config_ollama(tmp_path: Path) -> Generator[Path, None, None]:
 
     config_content = {
         "provider": "ollama",
-        "model": OLLAMA_TEST_MODEL,
         "providers": {
             "ollama": {
                 "base_url": "http://localhost:11434",

--- a/tests/integration/test_question_mode_real.py
+++ b/tests/integration/test_question_mode_real.py
@@ -28,7 +28,6 @@ def ollama_config_file(tmp_path):
 
     config = {
         "provider": "ollama",
-        "model": OLLAMA_TEST_MODEL,
         "providers": {"ollama": {"base_url": "http://localhost:11434", "model": OLLAMA_TEST_MODEL}},
         "context": {
             "include_history": False,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,6 @@ def create_sample_config(config_dir: Path, provider: str = "ollama") -> Path:
 
     config_data = {
         "provider": provider,
-        "model": OLLAMA_TEST_MODEL if provider == "ollama" else "gpt-4o-mini",
         "providers": {
             "openai": {
                 "api_key": "sk-test-key",


### PR DESCRIPTION
## Summary
- Removes deprecated top-level `model` field from 5 test config fixtures across 3 files
- The model was already correctly specified under `providers.<provider>.model` in each fixture
- Eliminates `DeprecationWarning` noise during test runs that could confuse stderr assertions
- Also found and fixed `tests/utils.py` which the original plan missed

## Files Changed
- `tests/conftest.py` — Removed from `test_config_openai`, `test_config_anthropic`, `test_config_ollama`
- `tests/integration/test_question_mode_real.py` — Removed from `ollama_config_file`
- `tests/utils.py` — Removed from `create_sample_config` (not in original issue, discovered during implementation)

## Test Plan
- [x] All 1106 tests passing (50 skipped due to missing providers)
- [x] No top-level model deprecation warnings from test fixtures
- [x] Zero code logic changes — only removed redundant config keys

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test configuration structure to consolidate model specifications under provider-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->